### PR TITLE
Do not fail if not found in path and try to match every path defined

### DIFF
--- a/src/Base/Schema.php
+++ b/src/Base/Schema.php
@@ -102,7 +102,7 @@ abstract class Schema
             if (preg_match($pathItemPattern, $uri->getPath(), $matches)) {
                 $pathDef = $this->jsonFile[self::SWAGGER_PATHS][$pathItem];
                 if (!isset($pathDef[$method])) {
-                    throw new HttpMethodNotFoundException("The http method '$method' not found in '$path'");
+                    continue;
                 }
 
                 $parametersPathMethod = [];


### PR DESCRIPTION
If paths in schema are defined without respect to logical order for matching, Schema will match first possible path and try to find a HTTP method in that path. 

If common path is matches first before concrete one, it fails on HttpMethodNotFoundException. 

For example:
- GET /api/pets/{id}
- POST /api/pets/create

Schema will match URL /api/pets/create on first path (assumes that id=create)